### PR TITLE
Update dependency on spikeextractors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
         'mountainlab_pytools',
         'h5py',
         'sklearn',
-#        'spikeextractors'
+        'spikeextractors>=0.4.1'
     ],
     classifiers=(
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Use v. 0.4.1 since this is when the functions we call were renamed.