### PR TITLE
using tempfile.gettempdir to get tmp folder

### DIFF
--- a/ml_ms4alg/mountainsort4.py
+++ b/ml_ms4alg/mountainsort4.py
@@ -26,7 +26,10 @@ def mountainsort4(*,recording,detect_sign,clip_size=50,adjacency_radius=-1,detec
     detect_threshold=detect_threshold,
     verbose=verbose
   )
-  tmpdir = tempfile.mkdtemp(dir=os.environ.get('TEMPDIR','/tmp'))
+  dir = os.environ.get('TEMPDIR')
+  if dir is None:
+    dir = tempfile.gettempdir()
+  tmpdir = tempfile.mkdtemp(dir)
   MS4.setNumWorkers(num_workers)
   if verbose:
     print('Using tmpdir: '+tmpdir)


### PR DESCRIPTION
Hi, this is a small change with a cross-platform way of getting the tmp directory without setting the TEMPDIR environment variable.